### PR TITLE
Replace bitnami image references with bitnamilegacy

### DIFF
--- a/apache.yml
+++ b/apache.yml
@@ -20,7 +20,7 @@ base:
     private: true
   containers:
     apache:
-      image: bitnami/apache
+      image: bitnamilegacy/apache
       image-tag: latest
 
 apache:


### PR DESCRIPTION
This PR replaces 'image: docker.io/bitnami/' and 'image: bitnami/' with their 'bitnamilegacy' equivalents, as per organization migration.